### PR TITLE
add failed state to spinner component

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,11 @@ A spinner will show a spinning indicator until the user calls it's `done` method
 final gift = Spinner(
   icon: '🏆',
   leftPrompt: (done) => '', // prompts are optional
-  rightPrompt: (done) => done
-      ? 'here is a trophy for being patient'
-      : 'searching a thing for you',
+  rightPrompt: (state) => switch (state) {
+      SpinnerStateType.inProgress => 'Processing...',
+      SpinnerStateType.done => 'Done!',
+      SpinnerStateType.failed => 'Failed!',
+    },
 ).interact();
 
 await Future.delayed(const Duration(seconds: 5));
@@ -185,7 +187,11 @@ final spinners = MultiSpinner();
 
 final horse = spinners.add(Spinner(
   icon: '🐴',
-  rightPrompt: (done) => done ? 'finished' : 'waiting',
+  rightPrompt: (state) => switch (state) {
+    SpinnerStateType.inProgress => 'Processing...',
+    SpinnerStateType.done => 'Done!',
+    SpinnerStateType.failed => 'Failed!',
+  },
 )); // notice how you don't need to call the `.interact()` function
 
 await Future.delayed(const Duration(seconds: 5));

--- a/example/exceptions.dart
+++ b/example/exceptions.dart
@@ -1,4 +1,4 @@
-import 'package:interact/interact.dart' show reset, Spinner;
+import 'package:interact/interact.dart' show Spinner, reset;
 
 Future<void> main() async {
   try {

--- a/example/multi_spinner.dart
+++ b/example/multi_spinner.dart
@@ -7,15 +7,10 @@ Future<void> main() async {
   final horse = spinners.add(
     Spinner(
       icon: '🐴',
-      rightPrompt: (state) {
-        switch (state) {
-          case SpinnerStateType.inProgress:
-            return 'Processing...';
-          case SpinnerStateType.done:
-            return 'Done!';
-          case SpinnerStateType.failed:
-            return 'Failed!';
-        }
+      rightPrompt: (state) => switch (state) {
+        SpinnerStateType.inProgress => 'Processing...',
+        SpinnerStateType.done => 'Done!',
+        SpinnerStateType.failed => 'Failed!',
       },
     ),
   );
@@ -23,15 +18,10 @@ Future<void> main() async {
   final rabbit = spinners.add(
     Spinner(
       icon: '🐇',
-      rightPrompt: (state) {
-        switch (state) {
-          case SpinnerStateType.inProgress:
-            return 'Processing...';
-          case SpinnerStateType.done:
-            return 'Done!';
-          case SpinnerStateType.failed:
-            return 'Failed!';
-        }
+      rightPrompt: (state) => switch (state) {
+        SpinnerStateType.inProgress => 'Processing...',
+        SpinnerStateType.done => 'Done!',
+        SpinnerStateType.failed => 'Failed!',
       },
     ),
   );
@@ -39,15 +29,11 @@ Future<void> main() async {
   final turtle = spinners.add(
     Spinner(
       icon: '🐢',
-      rightPrompt: (state) {
-        switch (state) {
-          case SpinnerStateType.inProgress:
-            return 'Processing...';
-          case SpinnerStateType.done:
-            return 'Done!';
-          case SpinnerStateType.failed:
-            return 'Failed!';
-        }
+      failedIcon: '✘',
+      rightPrompt: (state) => switch (state) {
+        SpinnerStateType.inProgress => 'Processing...',
+        SpinnerStateType.done => 'Done!',
+        SpinnerStateType.failed => 'Failed!',
       },
     ),
   );

--- a/example/multi_spinner.dart
+++ b/example/multi_spinner.dart
@@ -1,4 +1,5 @@
-import 'package:interact/interact.dart' show MultiSpinner, Spinner;
+import 'package:interact/interact.dart'
+    show MultiSpinner, Spinner, SpinnerStateType;
 
 Future<void> main() async {
   final spinners = MultiSpinner();
@@ -6,21 +7,48 @@ Future<void> main() async {
   final horse = spinners.add(
     Spinner(
       icon: '🐴',
-      rightPrompt: (done) => done ? 'finished' : 'waiting',
+      rightPrompt: (state) {
+        switch (state) {
+          case SpinnerStateType.inProgress:
+            return 'Processing...';
+          case SpinnerStateType.done:
+            return 'Done!';
+          case SpinnerStateType.failed:
+            return 'Failed!';
+        }
+      },
     ),
   );
 
   final rabbit = spinners.add(
     Spinner(
       icon: '🐇',
-      rightPrompt: (done) => done ? 'finished' : 'waiting',
+      rightPrompt: (state) {
+        switch (state) {
+          case SpinnerStateType.inProgress:
+            return 'Processing...';
+          case SpinnerStateType.done:
+            return 'Done!';
+          case SpinnerStateType.failed:
+            return 'Failed!';
+        }
+      },
     ),
   );
 
   final turtle = spinners.add(
     Spinner(
       icon: '🐢',
-      rightPrompt: (done) => done ? 'finished' : 'waiting',
+      rightPrompt: (state) {
+        switch (state) {
+          case SpinnerStateType.inProgress:
+            return 'Processing...';
+          case SpinnerStateType.done:
+            return 'Done!';
+          case SpinnerStateType.failed:
+            return 'Failed!';
+        }
+      },
     ),
   );
 
@@ -28,7 +56,7 @@ Future<void> main() async {
   horse.done();
 
   await Future.delayed(const Duration(seconds: 1));
-  rabbit.done();
+  rabbit.failed();
 
   await Future.delayed(const Duration(seconds: 2));
   turtle.done();

--- a/example/samples/npm_init.dart
+++ b/example/samples/npm_init.dart
@@ -1,5 +1,5 @@
 import 'dart:convert' show JsonEncoder;
-import 'dart:io' show stdout, stderr, exit;
+import 'dart:io' show exit, stderr, stdout;
 
 import 'package:interact/interact.dart';
 
@@ -82,7 +82,7 @@ void main() {
     'scripts': <String, String>{
       'test': testCommand.isNotEmpty
           ? testCommand
-          : 'echo "Error: no test specified" && exit 1'
+          : 'echo "Error: no test specified" && exit 1',
     },
     'keywords': keywords.isEmpty ? [] : keywords.split(' '),
     'license': license,

--- a/example/spinner.dart
+++ b/example/spinner.dart
@@ -6,15 +6,10 @@ Future<void> main() async {
   final gift = Spinner.withTheme(
     theme: theme,
     icon: '🏆',
-    rightPrompt: (state) {
-      switch (state) {
-        case SpinnerStateType.inProgress:
-          return 'Processing...';
-        case SpinnerStateType.done:
-          return 'Done!';
-        case SpinnerStateType.failed:
-          return 'Failed!';
-      }
+    rightPrompt: (state) => switch (state) {
+      SpinnerStateType.inProgress => 'Processing...',
+      SpinnerStateType.done => 'Done!',
+      SpinnerStateType.failed => 'Failed!',
     },
   ).interact();
 

--- a/example/spinner.dart
+++ b/example/spinner.dart
@@ -1,4 +1,4 @@
-import 'package:interact/interact.dart' show Spinner, Theme;
+import 'package:interact/interact.dart' show Spinner, SpinnerStateType, Theme;
 
 Future<void> main() async {
   final theme = Theme.basicTheme;
@@ -6,9 +6,16 @@ Future<void> main() async {
   final gift = Spinner.withTheme(
     theme: theme,
     icon: '🏆',
-    rightPrompt: (done) => done
-        ? 'here is a trophy for being patient'
-        : 'searching a thing for you',
+    rightPrompt: (state) {
+      switch (state) {
+        case SpinnerStateType.inProgress:
+          return 'Processing...';
+        case SpinnerStateType.done:
+          return 'Done!';
+        case SpinnerStateType.failed:
+          return 'Failed!';
+      }
+    },
   ).interact();
 
   await Future.delayed(const Duration(seconds: 5));

--- a/lib/interact.dart
+++ b/lib/interact.dart
@@ -1,5 +1,3 @@
-library interact;
-
 import 'package:interact/src/framework/framework.dart' show Context;
 
 export 'src/confirm.dart';

--- a/lib/src/confirm.dart
+++ b/lib/src/confirm.dart
@@ -100,7 +100,6 @@ class _ConfirmState extends State<Confirm> {
             if (!component.waitForNewLine) {
               return answer!;
             }
-            break;
           case 'n':
           case 'N':
             setState(() {
@@ -109,7 +108,6 @@ class _ConfirmState extends State<Confirm> {
             if (!component.waitForNewLine) {
               return answer!;
             }
-            break;
           default:
             break;
         }

--- a/lib/src/framework/component.dart
+++ b/lib/src/framework/component.dart
@@ -1,4 +1,4 @@
-part of interact.framework;
+part of 'framework.dart';
 
 /// A [Component] is an abstraction made with purpose
 /// of writing clear/managed state and rendering for

--- a/lib/src/framework/context.dart
+++ b/lib/src/framework/context.dart
@@ -1,4 +1,4 @@
-part of interact.framework;
+part of 'framework.dart';
 
 final _defaultConsole = Console();
 
@@ -113,43 +113,35 @@ class Context {
               buffer = buffer.substring(0, index - 1) + buffer.substring(index);
               index--;
             }
-            break;
           case ControlCharacter.delete:
           case ControlCharacter.ctrlD:
             if (index < buffer.length - 1) {
               buffer = buffer.substring(0, index) + buffer.substring(index + 1);
             }
-            break;
+
           case ControlCharacter.ctrlU:
             buffer = '';
             index = 0;
-            break;
           case ControlCharacter.ctrlK:
             buffer = buffer.substring(0, index);
-            break;
           case ControlCharacter.arrowLeft:
           case ControlCharacter.ctrlB:
             index = index > 0 ? index - 1 : index;
-            break;
           case ControlCharacter.arrowRight:
           case ControlCharacter.ctrlF:
             index = index < buffer.length ? index + 1 : index;
-            break;
           case ControlCharacter.wordLeft:
             if (index > 0) {
               final bufferLeftOfCursor = buffer.substring(0, index - 1);
               final lastSpace = bufferLeftOfCursor.lastIndexOf(' ');
               index = lastSpace != -1 ? lastSpace + 1 : 0;
             }
-            break;
           case ControlCharacter.home:
           case ControlCharacter.ctrlA:
             index = 0;
-            break;
           case ControlCharacter.end:
           case ControlCharacter.ctrlE:
             index = buffer.length;
-            break;
           default:
             break;
         }

--- a/lib/src/framework/state.dart
+++ b/lib/src/framework/state.dart
@@ -1,4 +1,4 @@
-part of interact.framework;
+part of 'framework.dart';
 
 /// Provides the structure and `setState` function.
 abstract class State<T extends Component> {

--- a/lib/src/multi_select.dart
+++ b/lib/src/multi_select.dart
@@ -140,12 +140,10 @@ class _MultiSelectState extends State<MultiSelect> {
             setState(() {
               index = (index - 1) % component.options.length;
             });
-            break;
           case ControlCharacter.arrowDown:
             setState(() {
               index = (index + 1) % component.options.length;
             });
-            break;
           case ControlCharacter.enter:
             return selection;
           default:

--- a/lib/src/multi_spinner.dart
+++ b/lib/src/multi_spinner.dart
@@ -52,6 +52,13 @@ class MultiSpinner {
         });
         return disposer;
       },
+      failed: () {
+        final disposer = _spinners[index].failed();
+        _dispose(() {
+          _disposers.add(disposer);
+        });
+        return disposer;
+      },
     );
 
     return state;

--- a/lib/src/select.dart
+++ b/lib/src/select.dart
@@ -108,12 +108,10 @@ class _SelectState extends State<Select> {
           setState(() {
             index = (index - 1) % component.options.length;
           });
-          break;
         case ControlCharacter.arrowDown:
           setState(() {
             index = (index + 1) % component.options.length;
           });
-          break;
         case ControlCharacter.enter:
           return index;
         default:

--- a/lib/src/sort.dart
+++ b/lib/src/sort.dart
@@ -125,7 +125,6 @@ class _SortState extends State<Sort> {
                 _up();
               }
             });
-            break;
           case ControlCharacter.arrowDown:
             setState(() {
               index = (index + 1) % component.options.length;
@@ -133,7 +132,6 @@ class _SortState extends State<Sort> {
                 _down();
               }
             });
-            break;
           case ControlCharacter.enter:
             return options.map((x) => component.options[x]).toList();
           default:

--- a/lib/src/spinner.dart
+++ b/lib/src/spinner.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show Timer, StreamSubscription;
+import 'dart:async' show StreamSubscription, Timer;
 import 'dart:io' show ProcessSignal;
 
 import 'package:interact/src/framework/framework.dart';

--- a/lib/src/spinner.dart
+++ b/lib/src/spinner.dart
@@ -5,24 +5,29 @@ import 'package:interact/src/framework/framework.dart';
 import 'package:interact/src/theme/theme.dart';
 import 'package:interact/src/utils/utils.dart';
 
-String _prompt(bool x) => '';
+String _prompt(SpinnerStateType _) => '';
+
+enum SpinnerStateType { inProgress, done, failed }
 
 /// A spinner or a loading indicator component.
 class Spinner extends Component<SpinnerState> {
   /// Construts a [Spinner] component with the default theme.
   Spinner({
     required this.icon,
+    String? failedIcon,
     this.leftPrompt = _prompt,
     this.rightPrompt = _prompt,
-  }) : theme = Theme.defaultTheme;
+  })  : theme = Theme.defaultTheme,
+        failedIcon = failedIcon ?? Theme.defaultTheme.errorPrefix;
 
   /// Constructs a [Spinner] component with the supplied theme.
   Spinner.withTheme({
     required this.icon,
+    String? failedIcon,
     required this.theme,
     this.leftPrompt = _prompt,
     this.rightPrompt = _prompt,
-  });
+  }) : failedIcon = failedIcon ?? Theme.defaultTheme.errorPrefix;
 
   Context? _context;
 
@@ -33,13 +38,17 @@ class Spinner extends Component<SpinnerState> {
   /// indicator after it's done.
   final String icon;
 
+  /// The icon to be shown in place of the loading
+  /// indicator after it's failed.
+  final String failedIcon;
+
   /// The prompt function to be shown on the left side
   /// of the spinning indicator or icon.
-  final String Function(bool) leftPrompt;
+  final String Function(SpinnerStateType) leftPrompt;
 
   /// The prompt function to be shown on the right side
   /// of the spinning indicator or icon.
-  final String Function(bool) rightPrompt;
+  final String Function(SpinnerStateType) rightPrompt;
 
   @override
   _SpinnerState createState() => _SpinnerState();
@@ -64,22 +73,26 @@ class Spinner extends Component<SpinnerState> {
 /// Handles a [Spinner]'s state.
 class SpinnerState {
   /// Constructs a state to manage a [Spinner].
-  SpinnerState({required this.done});
+  SpinnerState({required this.done, required this.failed});
 
   /// Function to be called to indicate that the
   /// spinner is loaded.
   void Function() Function() done;
+
+  /// Function to be called to indicate that the
+  /// spinner is failed.
+  void Function() Function() failed;
 }
 
 class _SpinnerState extends State<Spinner> {
-  late bool done;
+  late SpinnerStateType stateType;
   late int index;
   late StreamSubscription<ProcessSignal> sigint;
 
   @override
   void init() {
     super.init();
-    done = false;
+    stateType = SpinnerStateType.inProgress;
     index = 0;
     sigint = handleSigint();
     context.hideCursor();
@@ -95,15 +108,17 @@ class _SpinnerState extends State<Spinner> {
   void render() {
     final line = StringBuffer();
 
-    line.write(component.leftPrompt(done));
+    line.write(component.leftPrompt(stateType));
 
-    if (done) {
+    if (stateType == SpinnerStateType.done) {
       line.write(component.icon);
+    } else if (stateType == SpinnerStateType.failed) {
+      line.write(component.failedIcon);
     } else {
       line.write(component.theme.spinners[index]);
     }
     line.write(' ');
-    line.write(component.rightPrompt(done));
+    line.write(component.rightPrompt(stateType));
 
     context.writeln(line.toString());
   }
@@ -124,7 +139,20 @@ class _SpinnerState extends State<Spinner> {
     final state = SpinnerState(
       done: () {
         setState(() {
-          done = true;
+          stateType = SpinnerStateType.done;
+          sigint.cancel();
+        });
+        timer.cancel();
+        if (component._context != null) {
+          return dispose;
+        } else {
+          dispose();
+          return () {};
+        }
+      },
+      failed: () {
+        setState(() {
+          stateType = SpinnerStateType.failed;
           sigint.cancel();
         });
         timer.cancel();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.2.0
 repository: https://github.com/frencojobs/interact
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=3.1.2 <4.0.0"
 
 dependencies:
   dart_console: ^1.1.2


### PR DESCRIPTION
It's very common for some users to want to be able `failed` the spinner. 

For example, if some process went wrong.

I've added this feature to `spinner` and `multiSpinner` components.

Sample Code: 

``` dart 
Spinner(
  icon: '🐢',
  failedIcon: '✘',
  rightPrompt: (state) => switch (state) {
    SpinnerStateType.inProgress => 'Processing...',
    SpinnerStateType.done => 'Done!',
    SpinnerStateType.failed => 'Failed!',
  },

```


Result:

https://github.com/frencojobs/interact/assets/47558577/f8073e56-fa1e-4652-ae4d-fef670dc7ab1



